### PR TITLE
Add markdown documentation from memory branch

### DIFF
--- a/.kiro/memory/tech.md
+++ b/.kiro/memory/tech.md
@@ -63,7 +63,227 @@ assert!(stderr.contains("FeatureAlreadyExists"));
 4. 全体検証 → cargo test
 ```
 
+## 6. **rmcp 0.5.0 マイグレーション**
+**学び**: 公式SDKへの移行による大幅なコード削減と保守性向上
+```rust
+// ❌ カスタムJSON-RPC実装 (270行)
+pub struct CustomMcpServer {
+    // 手動JSON-RPCハンドリング
+}
+
+// ✅ rmcp Tool Router パターン (143行)
+#[derive(Clone)]
+pub struct MemoryMcpServer {
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router(router = tool_router)]
+impl MemoryMcpServer {
+    #[tool(name = "remember")]
+    pub async fn remember(&self, params: Parameters<RmcpRememberParams>) 
+        -> Result<Json<RmcpRememberResponse>, McpError> {
+        // 自動的なJSON-RPCハンドリング
+    }
+}
+```
+
+## 7. **未使用コード分析の重要性**
+**学び**: 設計仕様との照合による適切な判断
+```rust
+// ❌ 単純削除 - 設計仕様を無視
+warning: function `embed_text` is never used
+
+// ✅ 設計仕様確認 - Phase 3で必要と判明
+// デザイン仕様書 Section 5.4: "Generate embeddings fastembed"
+// → reindex機能で必要なため保持
+
+// ✅ 真に不要な機能のみ削除
+pub fn with_examples() -> Self { } // テストでも未使用
+```
+
+## 8. **条件付きコンパイルでのテスト専用メソッド**
+**学び**: `#[cfg(test)]`による適切な範囲制限
+```rust
+// ✅ テスト専用メソッドの正しい定義
+#[cfg(test)]
+pub fn with_tags(
+    memory_type: MemoryType,
+    topic: String,
+    content: String,
+    tags: Vec<String>,
+) -> Self {
+    // テスト時のみコンパイル
+    // 本番ビルドでは警告も出ない
+}
+```
+
+## 9. **データベースマイグレーション管理**
+**学び**: 段階的スキーマ拡張の重要性
+```rust
+// ✅ 適切なマイグレーション順序
+pub fn migrations() -> Migrations<'static> {
+    Migrations::new(vec![
+        M::up(include_str!("../../migrations/001_initial_schema.sql")),
+        M::up(include_str!("../../migrations/002_vector_storage.sql")), // 追加
+    ])
+}
+```
+
+## 10. **JSON Schemaとrmcp統合**
+**学び**: 構造化出力のための型安全性
+```rust
+// ✅ rmcp互換の型定義
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RmcpRememberParams {
+    pub r#type: String,           // Rust予約語のエスケープ
+    pub topic: String,
+    pub content: String,
+    pub tags: Option<Vec<String>>,
+}
+
+// ✅ 既存型との変換実装
+impl From<RmcpRememberParams> for RememberParams {
+    fn from(params: RmcpRememberParams) -> Self {
+        // 型変換ロジック
+    }
+}
+```
+
+## 11. **Borrowing CheckerとMutable Reference**
+**学び**: データを変更するメソッドには`&mut`が必須
+```rust
+// ❌ コンパイルエラー: cannot borrow as mutable
+fn import_memories(&self, repository: &SqliteMemoryRepository, memories: Vec<Memory>)
+
+// ✅ 解決: mutable referenceが必要
+fn import_memories(&self, repository: &mut SqliteMemoryRepository, memories: Vec<Memory>)
+let mut repository = SqliteMemoryRepository::new(&db_path)?;
+```
+
+## 12. **Error Trait Chain with thiserror**
+**学び**: `#[from]`で他のエラー型から自動変換、エラーチェーンで具体的な原因を保持
+```rust
+#[derive(Error, Debug)]
+pub enum HailMaryError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),  // 新しく追加
+}
+```
+
+## 13. **clap ValueEnum for CLI Integration**
+**学び**: `clap::ValueEnum`でenumを直接CLI引数として使用可能
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema, clap::ValueEnum)]
+pub enum MemoryType {
+    Tech, ProjectTech, Domain,
+}
+
+// CLI引数として自動的に使用可能
+#[arg(long, value_enum)]
+pub r#type: Option<MemoryType>,
+```
+
+## 14. **条件付きSerialization**
+**学び**: `skip_serializing_if`でJSONを簡潔に、API設計で重要
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExportMemory {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
+    #[serde(rename = "type")]
+    pub memory_type: String,
+}
+```
+
+## 15. **CSV Parsing with Quote Handling**
+**学び**: CSVのエスケープ処理、ダブルクォートは`""`で表現
+```rust
+// CSVフィールドの適切なエスケープ処理
+let value = if value.starts_with('"') && value.ends_with('"') && value.len() > 1 {
+    &value[1..value.len()-1].replace("\"\"", "\"")
+} else {
+    value
+};
+
+fn escape_csv_field(field: &str, delimiter: &str) -> String {
+    if field.contains(delimiter) || field.contains('"') || field.contains('\n') {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
+    }
+}
+```
+
+## 16. **Pattern Matching with Validation**
+**学び**: Resultのmatch文でエラーハンドリング、早期リターンパターン
+```rust
+let regex = if self.case_sensitive {
+    Regex::new(&self.query)
+} else {
+    Regex::new(&format!("(?i){}", self.query))
+};
+
+let regex = match regex {
+    Ok(r) => r,
+    Err(e) => {
+        eprintln!("Error: Invalid regex pattern: {}", e);
+        return Ok(Vec::new());  // 早期リターン
+    }
+};
+```
+
+## 17. **Iterator Chains with Complex Filtering**
+**学び**: `all()`と`any()`の組み合わせで複雑な条件フィルタリング
+```rust
+// 全てのタグが部分一致することを確認
+memories.retain(|m| {
+    filter_tags.iter().all(|tag| 
+        m.tags.iter().any(|mem_tag| 
+            mem_tag.to_lowercase().contains(&tag.to_lowercase())
+        )
+    )
+});
+
+// 年齢フィルタ
+if let Some(max_age) = self.max_age_days {
+    let cutoff_time = chrono::Utc::now().timestamp() - (max_age * 24 * 60 * 60);
+    memories.retain(|m| m.created_at >= cutoff_time);
+}
+```
+
+## 18. **String Formatting with Context**
+**学び**: 文字列の切り取りと条件付きフォーマット、ユーザビリティ向上
+```rust
+// プレビュー表示のための文字列切り取り
+let content = if memory.content.len() > 200 {
+    format!("{}...", &memory.content[..200])
+} else {
+    memory.content.clone()
+};
+
+// 複数パターンでの表示制御
+let snippet = if self.verbose {
+    &memory.content
+} else if self.snippets {
+    &preview_content
+} else {
+    &short_content
+};
+```
+
 ## 💡 **重要な気づき**
 - **テストファーストアプローチ**: エラーケースを先にテストすることで実装の抜け漏れを防止
 - **環境に依存しない設計**: テスト環境での実行を考慮した堅牢な実装
 - **段階的検証**: check → unit test → integration test の段階的アプローチが効果的
+- **設計仕様との整合性**: 未使用コード警告は設計文書と照合して判断する
+- **公式SDK活用**: カスタム実装より公式ライブラリを優先し、保守コストを削減
+- **条件付きコンパイル**: テスト専用機能は`#[cfg(test)]`で適切に分離
+- **Borrowing Checker理解**: 実行時エラーを防ぐコンパイル時チェックの重要性
+- **エラーチェーン設計**: 具体的なエラー原因を保持する階層的エラーハンドリング
+- **CLI設計**: enumとclapの統合でタイプセーフなコマンドライン引数
+- **データ変換設計**: JSONとCSVの相互変換における適切なエスケープ処理

--- a/.kiro/specs/2025-08-16-memory-mcp/embedding-implementation-plan.md
+++ b/.kiro/specs/2025-08-16-memory-mcp/embedding-implementation-plan.md
@@ -1,0 +1,407 @@
+# Embedding Feature Complete Integration Plan
+
+## Executive Summary
+Complete integration of embedding functionality for Memory MCP v2, enabling semantic search, similarity-based deduplication, and intelligent memory relationships using fastembed and sqlite-vec.
+
+## Architecture Overview
+
+### Core Components
+1. **fastembed** - Rust embedding generation library using ONNX models
+2. **sqlite-vec** - SQLite extension for vector storage and similarity search
+3. **Embedding Service** - Rust service layer for embedding operations
+4. **Similarity Engine** - Calculation and threshold-based matching system
+
+### Technical Stack
+- **Model**: all-MiniLM-L6-v2 (384 dimensions, balanced speed/quality)
+- **Vector Storage**: BLOB column in SQLite with vec0 virtual table
+- **Similarity Metric**: Cosine similarity for text embeddings
+- **Index Type**: HNSW (Hierarchical Navigable Small World) for sub-linear search
+
+## Implementation Phases
+
+### Phase 1: Core Infrastructure (2-3 days)
+**Objective**: Set up database schema and basic embedding generation
+
+#### Tasks:
+1. **Database Migration (002_vector_storage.sql)**
+   ```sql
+   ALTER TABLE memories ADD COLUMN embedding BLOB;
+   CREATE VIRTUAL TABLE vec_memories USING vec0(
+     id INTEGER PRIMARY KEY,
+     embedding FLOAT[384]
+   );
+   ```
+
+2. **Dependencies (Cargo.toml)**
+   ```toml
+   fastembed = "3.0"
+   sqlite-vec = "0.1"
+   ```
+
+3. **Embedding Service (`src/memory/embeddings.rs`)**
+   ```rust
+   pub struct EmbeddingService {
+       model: FastEmbed,
+       dimension: usize,
+   }
+   
+   impl EmbeddingService {
+       pub fn generate(&self, text: &str) -> Result<Vec<f32>>
+       pub fn batch_generate(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>
+   }
+   ```
+
+4. **Configuration**
+   - Model selection and caching
+   - Resource limits
+   - Feature flags
+
+### Phase 2: CRUD Integration (2 days)
+**Objective**: Auto-generate embeddings on memory operations
+
+#### Tasks:
+1. **Memory Creation Enhancement**
+   - Generate embedding on create
+   - Store in both main table and vector index
+
+2. **Memory Update Enhancement**
+   - Regenerate embedding when content changes
+   - Update vector index
+
+3. **Repository Methods**
+   ```rust
+   trait MemoryRepository {
+       fn store_embedding(&self, id: &str, embedding: &[f32]) -> Result<()>;
+       fn get_embedding(&self, id: &str) -> Result<Option<Vec<f32>>>;
+       fn search_similar(&self, embedding: &[f32], limit: usize) -> Result<Vec<Memory>>;
+   }
+   ```
+
+4. **Reindex Integration**
+   - Add `--generate-embeddings` flag
+   - Batch process memories without embeddings
+   - Progress reporting
+
+### Phase 3: Similarity Search (3 days)
+**Objective**: Implement semantic search and related memory discovery
+
+#### Tasks:
+1. **Semantic Search Command**
+   ```bash
+   memory search --semantic "query text" --top-k 10 --threshold 0.7
+   ```
+   - Generate query embedding
+   - Search vector index
+   - Combine with filters
+
+2. **Related Memories Command**
+   ```bash
+   memory related <id> --limit 5 --min-similarity 0.6
+   ```
+   - Get memory embedding
+   - Find nearest neighbors
+   - Exclude self
+
+3. **Distance Calculations**
+   - Cosine similarity implementation
+   - L2 distance as alternative
+   - Score normalization
+
+4. **Result Ranking**
+   - Combine semantic and keyword scores
+   - Configurable weights
+   - Explain scores option
+
+### Phase 4: Deduplication Enhancement (2 days)
+**Objective**: Use embeddings for intelligent duplicate detection
+
+#### Tasks:
+1. **Similarity-Based Detection**
+   ```bash
+   memory dedupe --similarity-threshold 0.9 --auto-merge
+   ```
+   - Find high-similarity pairs
+   - Group potential duplicates
+   - Suggest merge actions
+
+2. **Merge Logic**
+   - Combine metadata (tags, examples)
+   - Average confidence scores
+   - Preserve reference counts
+   - Keep audit trail
+
+3. **Interactive Mode**
+   - Show similarity scores
+   - Preview merge results
+   - Batch approval
+
+4. **Performance Optimization**
+   - Use LSH for candidate generation
+   - Parallel similarity computation
+   - Progress indicators
+
+### Phase 5: Advanced Features (3 days)
+**Objective**: Add clustering, analytics, and batch operations
+
+#### Tasks:
+1. **Clustering Command**
+   ```bash
+   memory cluster --algorithm dbscan --eps 0.3 --min-samples 5
+   ```
+   - DBSCAN implementation
+   - K-means alternative
+   - Export cluster assignments
+
+2. **Embedding Analytics**
+   ```bash
+   memory analytics embedding --detailed
+   ```
+   - Coverage metrics
+   - Dimension statistics
+   - Quality indicators
+   - Outlier detection
+
+3. **Batch Operations**
+   - Bulk embedding generation
+   - Parallel processing
+   - Progress tracking
+   - Error recovery
+
+4. **Visualization Export**
+   - Export embeddings for t-SNE/UMAP
+   - Generate similarity matrix
+   - Cluster visualization data
+
+### Phase 6: Performance Optimization (2 days)
+**Objective**: Optimize for production scale
+
+#### Tasks:
+1. **Indexing Strategy**
+   - HNSW index parameters tuning
+   - Incremental index updates
+   - Index persistence
+
+2. **Caching Layer**
+   - Model caching
+   - Embedding cache
+   - Query result cache
+
+3. **Resource Management**
+   - Memory pooling
+   - Batch size optimization
+   - Concurrent request limiting
+
+4. **Quantization**
+   - Int8 quantization option
+   - Binary embeddings for speed
+   - Quality/speed tradeoffs
+
+## Performance Requirements
+
+### Latency Targets
+- Embedding generation: <50ms per memory
+- Semantic search: <100ms for 10K memories
+- Similarity calculation: <10ms per pair
+- Batch processing: >100 memories/second
+
+### Resource Limits
+- Model memory: <500MB
+- Index memory: <100MB per 10K memories
+- CPU usage: <2 cores during operation
+- Disk cache: <1GB for model files
+
+### Quality Metrics
+- Search recall: >0.9 at k=10
+- Deduplication precision: >0.95
+- Clustering stability: >0.8 ARI
+- Embedding coverage: >99% after reindex
+
+## Error Handling
+
+### Failure Scenarios
+1. **Model Loading Failure**
+   - Fallback to keyword search
+   - Log error, continue operation
+   - Retry with exponential backoff
+
+2. **Embedding Generation Failure**
+   - Mark memory as pending
+   - Queue for retry
+   - Continue with partial results
+
+3. **Index Corruption**
+   - Detect via checksums
+   - Rebuild from embeddings
+   - Maintain operation log
+
+4. **Resource Exhaustion**
+   - Implement circuit breaker
+   - Degrade gracefully
+   - Alert and metrics
+
+## Testing Strategy
+
+### Unit Tests
+- Embedding generation with fixtures
+- Similarity calculations
+- Vector operations
+- Error conditions
+
+### Integration Tests
+- Database operations
+- Command workflows
+- Reindex with embeddings
+- Import/export with vectors
+
+### Performance Tests
+- Load testing (10K, 100K, 1M)
+- Latency benchmarks
+- Memory profiling
+- Concurrent operations
+
+### Quality Tests
+- Known similarity pairs
+- Deduplication accuracy
+- Clustering validity
+- Search relevance
+
+## Configuration Schema
+
+```toml
+[embeddings]
+enabled = true
+model = "all-MiniLM-L6-v2"
+dimension = 384
+cache_dir = "~/.cache/memory-mcp/models"
+
+[embeddings.generation]
+batch_size = 32
+max_length = 512
+auto_generate = true
+
+[embeddings.search]
+default_limit = 10
+min_similarity = 0.7
+use_reranking = false
+
+[embeddings.deduplication]
+threshold = 0.9
+auto_merge = false
+group_threshold = 0.85
+
+[embeddings.index]
+type = "hnsw"
+m_parameter = 16
+ef_construction = 200
+ef_search = 50
+
+[embeddings.resources]
+max_memory_mb = 500
+max_concurrent = 4
+cache_size_mb = 100
+```
+
+## Migration Path
+
+### Backward Compatibility
+- Embeddings optional by default
+- Gradual rollout via feature flags
+- Non-breaking schema changes
+- Parallel keyword search
+
+### Data Migration
+1. Add embedding column (nullable)
+2. Background generation job
+3. Gradual index building
+4. Feature flag activation
+
+### Rollback Plan
+1. Disable embedding features
+2. Keep embedding data
+3. Revert to keyword search
+4. No data loss
+
+## Success Criteria
+
+### Functional Requirements
+✅ Semantic search working
+✅ Deduplication via similarity
+✅ Related memory discovery
+✅ Clustering capabilities
+✅ Analytics integration
+
+### Performance Requirements
+✅ <100ms search latency
+✅ >100 memories/sec processing
+✅ <20% memory overhead
+✅ Linear scaling to 1M memories
+
+### Quality Requirements
+✅ >0.9 search recall
+✅ >0.95 dedup precision
+✅ Zero data loss
+✅ Graceful degradation
+
+## Implementation Schedule
+
+### Week 1
+- Day 1-2: Core infrastructure
+- Day 3-4: CRUD integration
+- Day 5: Testing and validation
+
+### Week 2
+- Day 1-2: Similarity search
+- Day 3-4: Deduplication
+- Day 5: Integration testing
+
+### Week 3
+- Day 1-2: Advanced features
+- Day 3-4: Performance optimization
+- Day 5: Final testing and documentation
+
+## Risk Assessment
+
+### Technical Risks
+- **Model compatibility**: Mitigate with version pinning
+- **Performance regression**: Mitigate with benchmarks
+- **Index corruption**: Mitigate with checksums
+- **Memory usage**: Mitigate with quantization
+
+### Operational Risks
+- **Breaking changes**: Mitigate with feature flags
+- **Data migration**: Mitigate with backups
+- **User adoption**: Mitigate with documentation
+
+## Dependencies
+
+### External Libraries
+- fastembed: 3.0+ (embedding generation)
+- sqlite-vec: 0.1+ (vector storage)
+- ndarray: 0.15+ (vector operations)
+- rayon: 1.7+ (parallel processing)
+
+### System Requirements
+- SQLite 3.40+ with loadable extensions
+- 1GB+ RAM for model
+- AVX2 CPU instructions (optional)
+- 2GB+ disk for model cache
+
+## Documentation Requirements
+
+### User Documentation
+- Command reference
+- Configuration guide
+- Migration guide
+- Performance tuning
+
+### Developer Documentation
+- API reference
+- Architecture diagrams
+- Testing guide
+- Troubleshooting
+
+### Examples
+- Semantic search workflows
+- Deduplication scenarios
+- Clustering use cases
+- Performance benchmarks

--- a/.kiro/specs/2025-08-16-memory-mcp/embedding-implementation-summary.md
+++ b/.kiro/specs/2025-08-16-memory-mcp/embedding-implementation-summary.md
@@ -1,0 +1,206 @@
+# Embedding機能完全統合 - 実装計画サマリー
+
+## 概要
+Memory MCP v2にベクトル埋め込み機能を完全統合し、セマンティック検索、類似性ベースの重複検出、メモリ関係性の発見を実現します。
+
+## 現在の状況
+
+### 既存のインフラ
+✅ **データベース準備完了**: `migrations/002_vector_storage.sql`が既に存在
+- `memory_embeddings`テーブル定義済み
+- `duplicate_memories`テーブルで類似性追跡
+- `reindex_history`で処理履歴管理
+- モデル指定: `BAAI/bge-small-en-v1.5`
+
+### 必要な実装
+- fastembed統合
+- sqlite-vec統合
+- 埋め込み生成サービス
+- 類似性検索API
+- 重複検出の強化
+
+## 実装フェーズ
+
+### 📅 フェーズ1: コアインフラ（2-3日）
+```rust
+// src/memory/embeddings.rs
+pub struct EmbeddingService {
+    model: FastEmbed,
+    dimension: usize,
+}
+```
+- ✅ データベーススキーマ（完了済み）
+- ⏳ fastembed依存関係追加
+- ⏳ 埋め込みサービス実装
+- ⏳ 設定管理
+
+### 📅 フェーズ2: CRUD統合（2日）
+```bash
+# 自動埋め込み生成
+memory create "新しいメモリ" --type tech  # 自動で埋め込み生成
+memory update <id> --content "更新内容"   # 埋め込み再生成
+```
+- ⏳ 作成時の自動生成
+- ⏳ 更新時の再生成
+- ⏳ リポジトリメソッド追加
+
+### 📅 フェーズ3: 類似性検索（3日）
+```bash
+# セマンティック検索
+memory search --semantic "機械学習の基礎" --top-k 10
+
+# 関連メモリ発見
+memory related <id> --limit 5
+```
+- ⏳ セマンティック検索コマンド
+- ⏳ 関連メモリコマンド
+- ⏳ 距離計算と順位付け
+
+### 📅 フェーズ4: 重複検出強化（2日）
+```bash
+# 類似性ベースの重複検出
+memory dedupe --similarity-threshold 0.9 --auto-merge
+```
+- ⏳ 類似性ベース検出
+- ⏳ マージロジック
+- ⏳ インタラクティブモード
+
+### 📅 フェーズ5: 高度な機能（3日）
+```bash
+# クラスタリング
+memory cluster --algorithm dbscan --eps 0.3
+
+# 埋め込み分析
+memory analytics embedding --detailed
+```
+- ⏳ クラスタリングコマンド
+- ⏳ 埋め込み分析
+- ⏳ バッチ操作
+
+### 📅 フェーズ6: パフォーマンス最適化（2日）
+- ⏳ HNSWインデックス
+- ⏳ キャッシング層
+- ⏳ 量子化オプション
+
+## 主要な技術的決定
+
+### アーキテクチャ
+| コンポーネント | 選択 | 理由 |
+|------------|------|-----|
+| 埋め込みライブラリ | fastembed | Rust native、高速 |
+| ベクトルDB | sqlite-vec | SQLite統合 |
+| モデル | BAAI/bge-small-en-v1.5 | バランスの良い性能 |
+| 類似度指標 | コサイン類似度 | テキスト埋め込みに最適 |
+| インデックス | HNSW | 高速近似検索 |
+
+### パフォーマンス目標
+- 埋め込み生成: <50ms/メモリ
+- セマンティック検索: <100ms（10Kメモリ）
+- バッチ処理: >100メモリ/秒
+- メモリオーバーヘッド: <20%
+
+### 品質目標
+- 検索再現率: >0.9 (k=10)
+- 重複検出精度: >0.95
+- 埋め込みカバレッジ: >99%
+
+## 実装優先順位
+
+### 🔴 必須機能（MVP）
+1. 基本的な埋め込み生成
+2. セマンティック検索
+3. 類似メモリ発見
+
+### 🟡 重要機能
+4. 重複検出強化
+5. リインデックス統合
+6. バッチ処理
+
+### 🟢 追加機能
+7. クラスタリング
+8. 高度な分析
+9. 可視化エクスポート
+
+## リスクと対策
+
+### 技術的リスク
+| リスク | 影響 | 対策 |
+|-------|------|-----|
+| モデル互換性 | 高 | バージョン固定、テスト |
+| パフォーマンス低下 | 中 | ベンチマーク、最適化 |
+| メモリ使用量 | 中 | 量子化、キャッシュ制限 |
+
+### 運用リスク
+| リスク | 影響 | 対策 |
+|-------|------|-----|
+| 破壊的変更 | 高 | フィーチャーフラグ |
+| データ移行 | 中 | バックアップ、段階的移行 |
+| ユーザー採用 | 低 | ドキュメント、例示 |
+
+## 次のステップ
+
+### 即座に開始可能
+1. **Cargo.toml更新**
+   ```toml
+   fastembed = "3.0"
+   sqlite-vec = "0.1"
+   ```
+
+2. **埋め込みサービス作成**
+   ```bash
+   touch src/memory/embeddings.rs
+   ```
+
+3. **テストの準備**
+   ```bash
+   touch tests/embedding_test.rs
+   ```
+
+### 週次マイルストーン
+- **Week 1**: コアインフラとCRUD統合
+- **Week 2**: 検索機能と重複検出
+- **Week 3**: 高度な機能と最適化
+
+## 成功の判断基準
+
+### 機能要件 ✅
+- [ ] セマンティック検索動作
+- [ ] 類似性による重複検出
+- [ ] 関連メモリ発見
+- [ ] クラスタリング機能
+
+### パフォーマンス要件 ✅
+- [ ] 検索遅延 <100ms
+- [ ] 処理速度 >100/秒
+- [ ] メモリ増加 <20%
+
+### 品質要件 ✅
+- [ ] 検索再現率 >0.9
+- [ ] 重複精度 >0.95
+- [ ] データ損失ゼロ
+
+## コマンド例
+
+```bash
+# 埋め込み生成（reindex時）
+hail-mary memory reindex --generate-embeddings --batch-size 32
+
+# セマンティック検索
+hail-mary memory search --semantic "Rustのメモリ管理" --top-k 10
+
+# 類似メモリ発見
+hail-mary memory related <memory-id> --threshold 0.7 --limit 5
+
+# 重複検出と統合
+hail-mary memory dedupe --similarity 0.9 --preview
+hail-mary memory dedupe --similarity 0.9 --auto-merge
+
+# クラスタリング
+hail-mary memory cluster --export clusters.json
+
+# 埋め込み分析
+hail-mary memory analytics embedding --format table
+```
+
+## 詳細ドキュメント
+完全な実装計画は[embedding-implementation-plan.md](./embedding-implementation-plan.md)を参照してください。

--- a/test-docs-2/domain.md
+++ b/test-docs-2/domain.md
@@ -1,0 +1,3 @@
+# Domain Knowledge
+
+*No memories recorded yet.*

--- a/test-docs-2/project-tech.md
+++ b/test-docs-2/project-tech.md
@@ -1,0 +1,3 @@
+# Project Technical Standards
+
+*No memories recorded yet.*

--- a/test-docs-2/tech.md
+++ b/test-docs-2/tech.md
@@ -1,0 +1,3 @@
+# Technical Knowledge
+
+*No memories recorded yet.*

--- a/test-docs/domain.md
+++ b/test-docs/domain.md
@@ -1,0 +1,3 @@
+# Domain Knowledge
+
+*No memories recorded yet.*

--- a/test-docs/project-tech.md
+++ b/test-docs/project-tech.md
@@ -1,0 +1,3 @@
+# Project Technical Standards
+
+*No memories recorded yet.*

--- a/test-docs/tech.md
+++ b/test-docs/tech.md
@@ -1,0 +1,3 @@
+# Technical Knowledge
+
+*No memories recorded yet.*


### PR DESCRIPTION
## Summary
- Add markdown files from memory branch to dev branch
- Includes memory management technical documentation
- MCP design specifications and implementation plans
- Reference documentation updates and test files

## Files Added/Modified
- `.kiro/memory/tech.md` - Memory management technical documentation
- `.kiro/specs/2025-08-16-memory-mcp/design2.md` - Updated MCP design specification
- `.kiro/specs/2025-08-16-memory-mcp/embedding-implementation-plan.md` - New embedding implementation plan
- `.kiro/specs/2025-08-16-memory-mcp/embedding-implementation-summary.md` - Implementation summary
- `reference/mcp-rust-mcp.md` - Updated MCP Rust reference
- `test-docs/` and `test-docs-2/` - Test documentation files

## Test plan
- [x] Verified only markdown files are included
- [x] No breaking changes to existing functionality
- [x] Documentation structure maintained
