### PR TITLE
fix: resolve SQLite database connection failure in uninitialized repositories

### DIFF
--- a/src/infrastructure/repositories/memory.rs
+++ b/src/infrastructure/repositories/memory.rs
@@ -16,6 +16,11 @@ pub struct SqliteMemoryRepository {
 
 impl SqliteMemoryRepository {
     pub fn new<P: AsRef<Path>>(db_path: P) -> Result<Self, ApplicationError> {
+        // Ensure parent directory exists for the database file
+        if let Some(parent) = db_path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
         let mut conn = Connection::open(db_path)?;
 
         // Set SQLite pragmas for performance and safety
@@ -359,6 +364,31 @@ mod tests {
     fn test_repository_creation() {
         let (_repo, _test_dir) = create_test_repository();
         // Test passes if repository creation doesn't panic
+    }
+    #[test]
+    fn test_repository_creation_with_non_existent_parent_directory() {
+        // Create a test directory but dont create the parent directories for the database
+        let test_dir = TestDirectory::new_no_cd();
+        let db_path = test_dir.path().join("non_existent_dir/memory/db.sqlite3");
+
+        // Ensure parent directories dont exist
+        assert!(!db_path.parent().unwrap().exists());
+
+        // Create repository - should automatically create parent directories
+        let repo = SqliteMemoryRepository::new(&db_path);
+        assert!(
+            repo.is_ok(),
+            "Should create repository even with non-existent parent dir"
+        );
+
+        // Verify parent directories were created
+        assert!(
+            db_path.parent().unwrap().exists(),
+            "Parent directory should be created"
+        );
+
+        // Verify database file exists
+        assert!(db_path.exists(), "Database file should be created");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When running `hail-mary memory serve` in a repository that hasn't been initialized with `hail-mary init`, the command would fail with the following error:

```
Error: SQLite error: unable to open database file
SQLite error code: 14 (SQLITE_CANTOPEN)
```

This occurred because the `SqliteMemoryRepository::new()` constructor assumed that the `.kiro/memory/` directory already existed, but this directory is only created during project initialization with the `hail-mary init` command.

## Root Cause

The issue was in `src/infrastructure/repositories/memory.rs` where the `SqliteMemoryRepository::new()` method directly attempted to open the SQLite database file without ensuring the parent directory structure existed.

## Solution

### Changes Made

1. **Automatic Directory Creation**: Modified `SqliteMemoryRepository::new()` to automatically create parent directories using `std::fs::create_dir_all()` before attempting to open the database connection.

2. **Robust Error Handling**: The directory creation uses the existing error handling infrastructure, converting filesystem errors into `ApplicationError` types.

3. **Comprehensive Testing**: Added `test_repository_creation_with_non_existent_parent_directory()` to verify the fix works correctly.

### Technical Details

The fix is minimal and safe:
- Uses `create_dir_all()` which is idempotent (safe to call on existing directories)
- Preserves all existing functionality and performance characteristics
- Only affects the initialization path, not runtime operations
- Follows the existing error handling patterns in the codebase

### Code Changes

```rust
// Before
let mut conn = Connection::open(db_path)?;

// After  
// Ensure parent directory exists for the database file
if let Some(parent) = db_path.as_ref().parent() {
    std::fs::create_dir_all(parent)?;
}

let mut conn = Connection::open(db_path)?;
```

## Test Coverage

- New test case verifies directory creation functionality
- All existing tests continue to pass (254 tests passing)
- Integration tests confirm the fix doesn't break existing functionality

## User Impact

### Before
Users had to run `hail-mary init` before using any memory commands, even when they just wanted to start the MCP server.

### After
Users can now run `hail-mary memory serve` in any directory, and the necessary directory structure will be created automatically.

## Validation

- [x] All tests pass (254/254)
- [x] Manual testing confirms fix resolves the issue
- [x] No performance impact on existing operations
- [x] Maintains backward compatibility

This fix improves the user experience by eliminating an unnecessary initialization step when users just want to use the memory server functionality.