### PR TITLE
feat: Add allowed_operations control for steering types

### DIFF
--- a/.claude/commands/hm/steering-remember.md
+++ b/.claude/commands/hm/steering-remember.md
@@ -276,6 +276,7 @@ User: 1
 >     "Security: Query depth limiting and validation",
 >     "Best Practices: Naming conventions and patterns"
 > ]
+> allowed_operations = []
 > 
 > ✅ Created graphql.md with your learning:
 > ## N+1 Query Prevention
@@ -354,9 +355,15 @@ criteria = [                                # Patterns for type matching
     "EXTERNAL_QUERY: Cloud SQL patterns",
     "Cost Management: Query cost strategies"
 ]
+allowed_operations = []                     # Auto-update control (new types default to manual-only)
 ```
 
 ### Property Details
 - **`name`**: Determines the steering filename (`{name}.md`)
 - **`purpose`**: Human-readable description shown during type selection
 - **`criteria`**: Array of patterns used for automatic type matching
+- **`allowed_operations`**: Controls automatic updates via `/hm:steering` command
+  - `["refresh", "discover"]` - Both update existing and add new information (default for product/tech/structure)
+  - `["refresh"]` - Only update out-of-date information
+  - `["discover"]` - Only add new discoveries
+  - `[]` - No automatic updates (manual-only via `/hm:steering-remember`) - **default for new types**

--- a/.kiro/config.toml
+++ b/.kiro/config.toml
@@ -2,6 +2,10 @@
 max = 10
 
 [[steering.types]]
+allowed_operations = [
+    "refresh",
+    "discover",
+]
 criteria = [
     "Product Overview: Brief description of what the product is",
     "Core Features: Bulleted list of main capabilities",
@@ -12,6 +16,10 @@ name = "product"
 purpose = "Product overview and value proposition"
 
 [[steering.types]]
+allowed_operations = [
+    "refresh",
+    "discover",
+]
 criteria = [
     "Architecture: High-level system design",
     "Frontend: Frameworks, libraries, build tools (if applicable)",
@@ -25,6 +33,10 @@ name = "tech"
 purpose = "Technical stack and development environment"
 
 [[steering.types]]
+allowed_operations = [
+    "refresh",
+    "discover",
+]
 criteria = [
     "Root Directory Organization: Top-level structure with descriptions",
     "Subdirectory Structures: Detailed breakdown of key directories",
@@ -37,23 +49,25 @@ name = "structure"
 purpose = "Code organization and project structure patterns"
 
 [[steering.types]]
+allowed_operations = []
 criteria = [
     "Command Syntax: Claude Code command structure and patterns",
     "File References: How to reference files in commands (@, paths)",
     "Tool Coordination: Optimal tool selection and usage patterns",
     "Best Practices: Effective command design and implementation",
-    "Integration Patterns: Claude Code workflow optimization"
+    "Integration Patterns: Claude Code workflow optimization",
 ]
 name = "prompt-engineering"
 purpose = "Claude Code command patterns and best practices"
 
 [[steering.types]]
+allowed_operations = []
 criteria = [
     "Markdown Syntax: Formatting rules and conventions",
     "Code Block Formatting: Proper nesting and syntax highlighting",
     "Documentation Structure: Organization and layout patterns",
     "Writing Style: Clear and concise technical writing",
-    "Formatting Standards: Consistent formatting across documentation"
+    "Formatting Standards: Consistent formatting across documentation",
 ]
 name = "documentation"
 purpose = "Documentation standards and best practices"

--- a/.kiro/specs/2025-09-13-strategy/design.md
+++ b/.kiro/specs/2025-09-13-strategy/design.md
@@ -1,0 +1,296 @@
+# Design
+
+## Overview
+Implement an update strategy system for steering types to control how the `/hm:steering` command updates different types of steering files. This allows fine-grained control over which steering files can be automatically refreshed or extended with new discoveries.
+
+## Architecture
+
+### Core Concept: allowed_operations
+Each steering type will have an `allowed_operations` property in config.toml that defines which automatic update operations are permitted:
+
+- `["refresh", "discover"]` - Both update existing and add new information (default for product, tech, structure)
+- `["refresh"]` - Only update out-of-date information
+- `["discover"]` - Only add new discoveries
+- `[]` - No automatic updates (manual updates only via `/hm:steering-remember`)
+
+### Component Design
+
+#### 1. Configuration Structure (TOML)
+```toml
+[steering.product]
+allowed_operations = ["refresh", "discover"]
+
+[steering.tech]
+allowed_operations = ["refresh", "discover"]
+
+[steering.structure]
+allowed_operations = ["refresh", "discover"]
+
+[steering.principles]
+allowed_operations = []  # Manual updates only
+
+[steering.decisions]
+allowed_operations = ["discover"]  # Only add new, don't modify existing
+```
+
+#### 2. Domain Model Updates
+
+##### File: `crates/hail-mary/src/domain/entities/steering.rs`
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SteeringType {
+    pub name: String,
+    pub purpose: String,
+    pub criteria: Vec<Criterion>,
+    #[serde(default = "default_allowed_operations")]
+    pub allowed_operations: Vec<String>,  // ["refresh", "discover"]
+}
+
+fn default_allowed_operations() -> Vec<String> {
+    vec![]  // Default to manual-only for safety
+}
+
+impl SteeringConfig {
+    pub fn default_for_new_project() -> Self {
+        Self {
+            backup: SteeringBackupConfig::default(),
+            types: vec![
+                SteeringType {
+                    name: "product".to_string(),
+                    purpose: "Product overview and value proposition".to_string(),
+                    criteria: vec![/* existing criteria */],
+                    allowed_operations: vec!["refresh".to_string(), "discover".to_string()],
+                },
+                SteeringType {
+                    name: "tech".to_string(),
+                    purpose: "Technical stack and development environment".to_string(),
+                    criteria: vec![/* existing criteria */],
+                    allowed_operations: vec!["refresh".to_string(), "discover".to_string()],
+                },
+                SteeringType {
+                    name: "structure".to_string(),
+                    purpose: "Code organization and project structure patterns".to_string(),
+                    criteria: vec![/* existing criteria */],
+                    allowed_operations: vec!["refresh".to_string(), "discover".to_string()],
+                },
+            ],
+        }
+    }
+}
+```
+
+##### File: `crates/hail-mary/src/infrastructure/repositories/config.rs`
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct SteeringTypeToml {
+    name: String,
+    purpose: String,
+    criteria: Vec<String>,
+    #[serde(default)]
+    allowed_operations: Vec<String>,  // New field
+}
+
+impl ConfigRepository {
+    fn parse_steering_config(steering_section: &SteeringSection) -> SteeringConfig {
+        let types = steering_section
+            .types
+            .iter()
+            .map(|t| SteeringType {
+                name: t.name.clone(),
+                purpose: t.purpose.clone(),
+                criteria: /* existing parsing */,
+                allowed_operations: t.allowed_operations.clone(),
+            })
+            .collect();
+
+        SteeringConfig { types, backup }
+    }
+
+    fn ensure_allowed_operations(&self) -> Result<(), ApplicationError> {
+        let mut toml_value = self.load_toml()?;
+        let table = toml_value.as_table_mut().ok_or_else(/* error */)?;
+
+        if let Some(steering) = table.get_mut("steering")
+            && let Some(steering_table) = steering.as_table_mut()
+        {
+            // Iterate through each steering type
+            for (type_name, type_value) in steering_table.iter_mut() {
+                if let Some(type_table) = type_value.as_table_mut() {
+                    if !type_table.contains_key("allowed_operations") {
+                        // Add default based on type name
+                        let default_ops = match type_name.as_str() {
+                            "product" | "tech" | "structure" =>
+                                vec!["refresh".to_string(), "discover".to_string()],
+                            _ => vec![],
+                        };
+
+                        let ops_value = toml::Value::Array(
+                            default_ops.into_iter()
+                                .map(toml::Value::String)
+                                .collect()
+                        );
+                        type_table.insert("allowed_operations".to_string(), ops_value);
+                    }
+                }
+            }
+
+            self.save_toml(&toml_value)?;
+        }
+
+        Ok(())
+    }
+}
+```
+
+##### File: `crates/hail-mary/src/application/use_cases/initialize_project.rs`
+```rust
+pub fn initialize_project(
+    config_repo: &dyn ConfigRepositoryInterface,
+    _spec_repo: &dyn SpecRepositoryInterface,
+    steering_repo: &dyn SteeringRepositoryInterface,
+) -> Result<(), ApplicationError> {
+    // Existing initialization steps...
+
+    // NEW: Ensure allowed_operations exist for all steering types
+    config_repo.ensure_allowed_operations()?;
+
+    // Continue with existing steps...
+    Ok(())
+}
+```
+
+#### 3. Slash Command Updates
+
+##### File: `.claude/commands/hm/steering-remember.md`
+Update the type creation flow to automatically add `allowed_operations = []`:
+
+```markdown
+## Config.toml Structure
+When creating a new steering type, the command adds:
+
+[steering.{type_name}]
+name = "{type_name}"
+purpose = "{purpose}"
+criteria = [...]
+allowed_operations = []  # New types default to manual-only
+
+## Behavioral Flow
+Step 3: When creating new type:
+- Automatically sets allowed_operations = [] for safety
+- Documents in user feedback that automatic updates are disabled
+- User can manually edit config.toml later to enable operations
+```
+
+##### File: `.claude/commands/hm/steering.md`
+Update the investigation phase to respect `allowed_operations`:
+
+```markdown
+## Config.toml Structure
+Each steering type can control automatic updates via allowed_operations:
+- ["refresh", "discover"] - Both update and add (default for product/tech/structure)
+- ["refresh"] - Only update existing information
+- ["discover"] - Only add new discoveries
+- [] - Skip automatic updates (manual-only via steering-remember)
+
+## Behavioral Flow
+Step 3: Investigation Phase
+- Load allowed_operations for each type from config.toml
+- Skip types with empty allowed_operations []
+- For types with operations:
+  - If "refresh" in allowed_operations: Check for outdated information
+  - If "discover" in allowed_operations: Look for new patterns
+
+Example output:
+> Analyzing steering types...
+> • product.md [refresh ✅, discover ✅] - Will check and update
+> • tech.md [refresh ✅, discover ✅] - Will check and update
+> • principles.md [skipped - no operations allowed]
+> • decisions.md [discover ✅] - Will only add new content
+```
+
+#### 4. Command Behavior
+
+##### `/hm:steering-remember` Command
+- Always allows manual additions to any steering type (ignores `allowed_operations`)
+- When creating new steering types, automatically sets `allowed_operations = []`
+- Appends to existing files using Edit/MultiEdit tools
+- Creates new files with Write tool when new type is created
+
+##### `/hm:steering` Command
+- Reads `allowed_operations` for each steering type from config.toml
+- Skips types where `allowed_operations = []`
+- For each type with operations:
+  - If "refresh" in `allowed_operations`: Update out-of-date information
+  - If "discover" in `allowed_operations`: Add new discoveries
+- Reports which types were processed and which were skipped
+
+##### `hail-mary init` Command
+- When initializing a project:
+  1. Creates default steering types if not present
+  2. Ensures all steering types have `allowed_operations` property
+  3. Sets defaults based on type name:
+     - product, tech, structure → `["refresh", "discover"]`
+     - All other types → `[]`
+  4. Never overwrites existing `allowed_operations` values
+
+### Implementation Strategy
+
+#### Phase 1: Documentation Updates
+1. **Update `.claude/commands/hm/steering-remember.md`**:
+   - Add Config.toml Structure section explaining `allowed_operations` property
+   - Document that new types default to `allowed_operations = []`
+   - Update type creation flow to include the new property
+
+2. **Update `.claude/commands/hm/steering.md`**:
+   - Add Config.toml Structure section explaining `allowed_operations` property
+   - Document the investigation phase changes to check `allowed_operations`
+   - Add example output showing skipped types
+
+#### Phase 2: Code Implementation
+
+1. **Update domain model** (`crates/hail-mary/src/domain/entities/steering.rs`):
+   - Add `allowed_operations: Vec<String>` field to `SteeringType` struct
+   - Add `#[serde(default = "default_allowed_operations")]` attribute
+   - Update `default_for_new_project()` to include allowed_operations for default types
+
+2. **Update infrastructure** (`crates/hail-mary/src/infrastructure/repositories/config.rs`):
+   - Add `allowed_operations` field to `SteeringTypeToml` struct
+   - Update `parse_steering_config()` to handle the new field
+   - Add `ensure_allowed_operations()` method to add missing properties
+   - Update serialization logic to include allowed_operations
+
+3. **Update init use case** (`crates/hail-mary/src/application/use_cases/initialize_project.rs`):
+   - Call `ensure_allowed_operations()` after config initialization
+   - Ensure idempotent behavior
+
+4. **Update repository interface** (`crates/hail-mary/src/application/repositories/config_repository.rs`):
+   - Add `ensure_allowed_operations()` to the trait
+
+#### Phase 3: Testing
+1. **Domain tests**:
+   - Test SteeringType serialization/deserialization with allowed_operations
+   - Test default values for allowed_operations
+
+2. **Infrastructure tests**:
+   - Test parsing config with and without allowed_operations
+   - Test ensure_allowed_operations() adds correct defaults
+   - Test idempotent behavior
+
+3. **Integration tests**:
+   - Test `hail-mary init` adds allowed_operations to existing configs
+   - Test new projects get correct defaults
+
+### Migration Path
+For existing projects without `allowed_operations`:
+1. `hail-mary init` will detect missing properties and add them
+2. Preserves existing steering configuration while adding new properties
+3. Non-destructive update that maintains backward compatibility
+
+### Benefits
+1. **Fine-grained control**: Each steering type can have different update policies
+2. **Safe defaults**: New types default to manual-only updates
+3. **Clear intent**: Configuration explicitly states what's allowed
+4. **Preservation of critical content**: Principles, decisions, etc. can be protected
+5. **Flexibility**: Easy to adjust behavior per type as needs evolve

--- a/.kiro/specs/2025-09-13-strategy/memo.md
+++ b/.kiro/specs/2025-09-13-strategy/memo.md
@@ -1,0 +1,84 @@
+# Memo: strategy
+
+steeringのtypesのデフォルトでproduct, tech, structureを作成していて、残りは `/hm:steering-remember` で必要なタイミングで作成されたりする
+そして、steering fileがout-of-dateになったりするのを防ぐために、 `/hm:steering` で最新化を促すようにしている
+特に、`new discovery` とかもあって、劣化を防ぐだけじゃなくて新しい発見もあれば追記するように `/hm:steering` で実現できている
+
+この運用自体はとても最高なんだけど、問題がある。
+steering typeでproduct, tech, structureは劣化しやすいので、`/hm:steering` で最新化を促すのは良いんだけど、他のtypesはあまり劣化しづらい。
+typeによっては勝手にnew discoveryされたくないものもあれば、
+typeによっては`/hm:steering` で更新されてほしくない場合もある。`/hm:steering-remember` で追加されることはあっても、`/hm:steering` で更新されることを期待していない
+
+どのような運用にすればいいと思う？
+
+---
+
+update_strategyを追加する方針でも良いと思うんだけど、どういうstrategyがあるか整理してほしい
+`/hm:steering-remember` で追加されることはあっても、`/hm:steering` で更新されることを期待していないtypeがある
+
+`/hm:steering-remember` は update_strategyに関係なく、常に追加される
+`/hm:steering` は update_strategyによって挙動が変わる
+  - refresh: 常に最新化を促す
+  - stable: 劣化しづらいので、new discoveryがあった場合
+  - frozen: `/hm:steering` で更新されることを期待していない
+  - custom: カスタムプロンプトを指定できる
+  - none: `/hm:steering` で更新されない
+  - manual: 手動で更新される
+  - auto: 自動で更新される
+
+- out-of-dateの情報の更新。new discoveryがあった場合の追加
+- out-of-dateの情報の更新のみ
+- new discoveryがあった場合の追加のみ
+- なにもしない
+
+---
+
+配列いいよね。じゃあ、配列にしようかな
+[], ['refresh'], ['discover'], ['refresh', 'discover']だけだよね
+
+以下は、私が考える修正案
+- steering-remember.md には、新しいsteering typesを追加するときはallowed_operationsに空配列を追加するように書いてほしい
+- steering.md には、 それぞれのtypeのallowed_operationsをみて、どのファイルをどのように修正するべきか考えるようにしてほしいと書いてほしい
+- 残りのhail-maryのコマンドで、
+  - initコマンド: `hail-mary init` した時に、allowed_operations propertyがなければ、追加する。structure, tech, productは['refresh', 'discover']を追加
+その他で影響範囲あるかどうか調査してほしい
+
+- default_とかいらない。hail-mary initした時に必ず allowed_operations propertyを追加するから
+- steering-remember はデフォルトで空配列を追加させるようにしてほしいので、フラグは不要
+- steering-rememberの Steering Type追加時の説明はそれでいいともう
+- steering.md もそれで良いと思う。未定義の場合はないから考慮しなくていい
+- steering-remember.md とsteering.md の Config.toml Structure sectionに allowed_operations propertyの説明を追加してほしい
+- `--verbose` は要らん
+
+---
+
+いや、期待通りに動いていない
+例えば、既に.kiro/config.tomlに
+
+```markdown
+[[steering.types]]
+criteria = [
+"Root Directory Organization: Top-level structure with descriptions",
+"Subdirectory Structures: Detailed breakdown of key directories",
+"Code Organization Patterns: How code is structured",
+"File Naming Conventions: Standards for naming files and directories",
+"Import Organization: How imports/dependencies are organized",
+"Key Architectural Principles: Core design decisions and patterns",
+]
+name = "structure"
+purpose = "Code organization and project structure patterns"
+
+
+[[steering.types]]
+criteria = [
+"Markdown Syntax: Formatting rules and conventions",
+"Code Block Formatting: Proper nesting and syntax highlighting",
+"Documentation Structure: Organization and layout patterns",
+"Writing Style: Clear and concise technical writing",
+"Formatting Standards: Consistent formatting across documentation"
+]
+name = "documentation"
+purpose = "Documentation standards and best practices"
+```
+
+がある時、それぞれのsteering.typesにallowed_operationsがないので、`hail-mary init` した時に追加されるべきなんだけど、されていない

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ The steering system provides transparent, version-controllable context managemen
 ### Key Features
 - **File-Based Storage**: Context stored as markdown files in `.kiro/steering/`
 - **Version Control Friendly**: All steering files can be tracked in git
-- **Claude Code Integration**: Slash commands for draft management and categorization
+- **Claude Code Integration**: Slash commands for managing steering content
 - **Smart Configuration**: Automatically adds [steering] section to existing config.toml
 
 ### Directory Structure
@@ -168,8 +168,7 @@ The steering system provides transparent, version-controllable context managemen
 │   ├── product.md              # Product overview and value proposition
 │   ├── tech.md                 # Technical stack and development environment
 │   ├── structure.md            # Code organization patterns
-│   ├── backup/                 # Backups before modifications
-│   └── draft/                  # Temporary drafts for processing
+│   └── backup/                 # Backups before modifications
 └── config.toml                 # Contains [steering] configuration
 ```
 
@@ -179,13 +178,13 @@ The steering system provides transparent, version-controllable context managemen
 3. **Structure**: Directory organization, code patterns, naming conventions, principles
 
 ### Slash Commands
-- `/hm:steering-remember [title]`: Save new learnings to draft directory
-- `/hm:steering [--verbose] [--dry-run]`: Process drafts and categorize into steering files
+- `/hm:steering-remember [title]`: Save new learnings directly to steering files
+- `/hm:steering [--verbose] [--dry-run]`: Update and maintain steering files
 
 ### Workflow
 1. **Initialize**: `hail-mary init` creates steering directories and default files
-2. **Capture**: Use `/hm:steering-remember` during Claude Code sessions to save important context
-3. **Organize**: Use `/hm:steering` to categorize drafts into appropriate steering files
+2. **Capture**: Use `/hm:steering-remember` during Claude Code sessions to save important context directly to steering files
+3. **Maintain**: Use `/hm:steering` to update and refresh steering files
 4. **Reference**: Steering files provide persistent context for future development sessions
 
 ## Key Implementation Details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ The steering system provides transparent, version-controllable context managemen
 - **Version Control Friendly**: All steering files can be tracked in git
 - **Claude Code Integration**: Slash commands for managing steering content
 - **Smart Configuration**: Automatically adds [steering] section to existing config.toml
+- **Update Strategy Control**: Fine-grained control over which steering files can be automatically updated
 
 ### Directory Structure
 ```
@@ -177,15 +178,39 @@ The steering system provides transparent, version-controllable context managemen
 2. **Tech**: Architecture, frontend/backend stack, development environment, commands
 3. **Structure**: Directory organization, code patterns, naming conventions, principles
 
+### Update Strategy System
+Each steering type has an `allowed_operations` property that controls automatic updates via `/hm:steering`:
+
+- **`["refresh", "discover"]`** - Both update existing and add new information (default for product, tech, structure)
+- **`["refresh"]`** - Only update out-of-date information
+- **`["discover"]`** - Only add new discoveries
+- **`[]`** - No automatic updates (manual updates only via `/hm:steering-remember`)
+
+#### Configuration Example
+```toml
+[[steering.types]]
+name = "product"
+purpose = "Product overview and value proposition"
+criteria = [...]
+allowed_operations = ["refresh", "discover"]
+
+[[steering.types]]
+name = "principles"
+purpose = "Core project principles"
+criteria = [...]
+allowed_operations = []  # Manual updates only
+```
+
 ### Slash Commands
-- `/hm:steering-remember [title]`: Save new learnings directly to steering files
-- `/hm:steering [--verbose] [--dry-run]`: Update and maintain steering files
+- `/hm:steering-remember [title]`: Save new learnings directly to steering files (ignores `allowed_operations`)
+- `/hm:steering [--verbose] [--dry-run]`: Update and maintain steering files (respects `allowed_operations`)
 
 ### Workflow
-1. **Initialize**: `hail-mary init` creates steering directories and default files
+1. **Initialize**: `hail-mary init` creates steering directories, default files, and adds `allowed_operations` to existing types
 2. **Capture**: Use `/hm:steering-remember` during Claude Code sessions to save important context directly to steering files
-3. **Maintain**: Use `/hm:steering` to update and refresh steering files
+3. **Maintain**: Use `/hm:steering` to update and refresh steering files based on their `allowed_operations` settings
 4. **Reference**: Steering files provide persistent context for future development sessions
+5. **Configure**: Manually edit `allowed_operations` in config.toml to control which files can be automatically updated
 
 ## Key Implementation Details
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ criteria = [
     "Target Use Case: Specific scenarios the product addresses",
     "Key Value Proposition: Unique benefits and differentiators",
 ]
+allowed_operations = ["refresh", "discover"]  # Default for core types
 
 [[steering.types]]
 name = "tech"
@@ -193,6 +194,7 @@ criteria = [
     "Development Environment: Required tools and setup",
     "Common Commands: Frequently used development commands",
 ]
+allowed_operations = ["refresh", "discover"]  # Default for core types
 
 [[steering.types]]
 name = "structure"
@@ -202,6 +204,16 @@ criteria = [
     "Code Organization Patterns: How code is structured",
     "Key Architectural Principles: Core design decisions",
 ]
+allowed_operations = ["refresh", "discover"]  # Default for core types
+
+[[steering.types]]
+name = "principles"
+purpose = "Core project principles"
+criteria = [
+    "Design Principles: Fundamental design decisions",
+    "Development Guidelines: Code quality standards",
+]
+allowed_operations = []  # Manual updates only
 ```
 
 ### Steering System Types
@@ -209,6 +221,15 @@ criteria = [
 - **`product`**: Product overview, features, and value proposition documentation
 - **`tech`**: Technology stack, development environment, and command reference
 - **`structure`**: Code organization, architectural patterns, and structural decisions
+
+### Update Strategy Control
+
+Each steering type includes an `allowed_operations` property that controls automatic updates:
+
+- **`["refresh", "discover"]`** - Update existing info and add new discoveries (default for product, tech, structure)
+- **`["refresh"]`** - Only update existing information
+- **`["discover"]`** - Only add new discoveries
+- **`[]`** - Manual updates only via `/hm:steering-remember`
 
 ### File System Organization
 
@@ -320,10 +341,11 @@ cargo test --test integration_repository_test
 
 ### Steering System Workflow
 
-1. **Capture**: Use `/hm:steering-remember` during Claude Code sessions to save insights
-2. **Maintain**: Run `/hm:steering` to update and refresh steering files
-3. **Version Control**: Commit steering changes to share context with team members
-4. **Context Loading**: Steering files automatically provide persistent context for development
+1. **Capture**: Use `/hm:steering-remember` during Claude Code sessions to save insights (ignores `allowed_operations`)
+2. **Maintain**: Run `/hm:steering` to update and refresh steering files (respects `allowed_operations` settings)
+3. **Configure**: Edit `allowed_operations` in config.toml to control which files can be automatically updated
+4. **Version Control**: Commit steering changes to share context with team members
+5. **Context Loading**: Steering files automatically provide persistent context for development
 
 ## 🔒 Security
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ The steering system uses git-trackable markdown files:
 - `.kiro/steering/product.md`: Product context (always loaded)
 - `.kiro/steering/tech.md`: Technical context (always loaded)
 - `.kiro/steering/structure.md`: Structural context (always loaded)
-- `.kiro/steering/draft/`: Temporary drafts for processing
 
 ## 🔌 Claude Code Integration
 
@@ -238,8 +237,8 @@ Hail-mary integrates with Claude Code through structured system prompts that pro
 
 Hail-mary provides custom Claude Code slash commands in `.claude/commands/hm/`:
 
-- `/hm:steering`: Main steering management command - processes drafts and updates steering files
-- `/hm:steering-remember [title]`: Capture learning and insights to drafts for later processing  
+- `/hm:steering`: Main steering management command - updates and maintains steering files
+- `/hm:steering-remember [title]`: Capture learning and insights directly to steering files  
 - `/hm:steering-merge`: Advanced merging of steering content with conflict resolution
 
 ### Steering System Context
@@ -322,7 +321,7 @@ cargo test --test integration_repository_test
 ### Steering System Workflow
 
 1. **Capture**: Use `/hm:steering-remember` during Claude Code sessions to save insights
-2. **Process**: Run `/hm:steering` to intelligently categorize drafts into steering files
+2. **Maintain**: Run `/hm:steering` to update and refresh steering files
 3. **Version Control**: Commit steering changes to share context with team members
 4. **Context Loading**: Steering files automatically provide persistent context for development
 

--- a/crates/hail-mary/src/application/repositories/config_repository.rs
+++ b/crates/hail-mary/src/application/repositories/config_repository.rs
@@ -21,4 +21,7 @@ pub trait ConfigRepositoryInterface {
 
     /// Ensure steering backup configuration exists, adding defaults if missing
     fn ensure_steering_backup_config(&self) -> Result<(), ApplicationError>;
+
+    /// Ensure allowed_operations exists for all steering types, adding defaults if missing
+    fn ensure_allowed_operations(&self) -> Result<(), ApplicationError>;
 }

--- a/crates/hail-mary/src/application/test_helpers/mock_config_repository.rs
+++ b/crates/hail-mary/src/application/test_helpers/mock_config_repository.rs
@@ -127,4 +127,15 @@ impl ConfigRepositoryInterface for MockConfigRepository {
         // For testing purposes, this is a no-op
         Ok(())
     }
+
+    fn ensure_allowed_operations(&self) -> Result<(), ApplicationError> {
+        if self.should_fail("ensure_allowed_operations") {
+            return Err(ApplicationError::ConfigurationError(
+                "Mock ensure allowed operations failure".to_string(),
+            ));
+        }
+
+        // For testing purposes, this is a no-op
+        Ok(())
+    }
 }

--- a/crates/hail-mary/src/application/use_cases/backup_steering.rs
+++ b/crates/hail-mary/src/application/use_cases/backup_steering.rs
@@ -5,7 +5,7 @@ use chrono::Local;
 /// Creates a backup of all steering files with automatic rotation
 ///
 /// This function:
-/// 1. Lists all steering markdown files (excluding backup/draft directories)
+/// 1. Lists all steering markdown files (excluding backup directory)
 /// 2. Creates a timestamped backup directory
 /// 3. Copies all files to the backup
 /// 4. Enforces the maximum backup limit by deleting oldest backups

--- a/crates/hail-mary/src/application/use_cases/initialize_project.rs
+++ b/crates/hail-mary/src/application/use_cases/initialize_project.rs
@@ -19,6 +19,9 @@ pub fn initialize_project(
     // Ensure steering backup configuration exists (idempotent)
     config_repo.ensure_steering_backup_config()?;
 
+    // Ensure allowed_operations exists for all steering types (idempotent)
+    config_repo.ensure_allowed_operations()?;
+
     // Save default config if it doesn't exist
     let config = ProjectConfig::default_for_new_project();
     config_repo.save_config(&config)?;

--- a/crates/hail-mary/src/domain/entities/steering.rs
+++ b/crates/hail-mary/src/domain/entities/steering.rs
@@ -6,6 +6,12 @@ pub struct SteeringType {
     pub name: String,
     pub purpose: String,
     pub criteria: Vec<Criterion>,
+    #[serde(default = "default_allowed_operations")]
+    pub allowed_operations: Vec<String>,
+}
+
+fn default_allowed_operations() -> Vec<String> {
+    vec![] // Default to manual-only for safety
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -85,6 +91,7 @@ impl SteeringConfig {
                             description: "Unique benefits and differentiators".to_string(),
                         },
                     ],
+                    allowed_operations: vec!["refresh".to_string(), "discover".to_string()],
                 },
                 SteeringType {
                     name: "tech".to_string(),
@@ -121,6 +128,7 @@ impl SteeringConfig {
                             description: "Standard ports used by services".to_string(),
                         },
                     ],
+                    allowed_operations: vec!["refresh".to_string(), "discover".to_string()],
                 },
                 SteeringType {
                     name: "structure".to_string(),
@@ -151,6 +159,7 @@ impl SteeringConfig {
                             description: "Core design decisions and patterns".to_string(),
                         },
                     ],
+                    allowed_operations: vec!["refresh".to_string(), "discover".to_string()],
                 },
             ],
         }
@@ -176,6 +185,7 @@ impl SteeringConfig {
             name: name.to_string(),
             purpose: purpose.to_string(),
             criteria,
+            allowed_operations: vec![], // New types default to manual-only
         })
     }
 }
@@ -253,6 +263,7 @@ mod tests {
         assert_eq!(product.purpose, "Product overview and value proposition");
         assert_eq!(product.criteria.len(), 4);
         assert_eq!(product.criteria[0].name, "Product Overview");
+        assert_eq!(product.allowed_operations, vec!["refresh", "discover"]);
 
         // Test tech type
         let tech = &config.types[1];
@@ -260,6 +271,7 @@ mod tests {
         assert_eq!(tech.purpose, "Technical stack and development environment");
         assert_eq!(tech.criteria.len(), 7);
         assert_eq!(tech.criteria[0].name, "Architecture");
+        assert_eq!(tech.allowed_operations, vec!["refresh", "discover"]);
 
         // Test structure type
         let structure = &config.types[2];
@@ -270,6 +282,7 @@ mod tests {
         );
         assert_eq!(structure.criteria.len(), 6);
         assert_eq!(structure.criteria[0].name, "Root Directory Organization");
+        assert_eq!(structure.allowed_operations, vec!["refresh", "discover"]);
     }
 
     #[test]
@@ -289,6 +302,7 @@ mod tests {
         assert_eq!(steering_type.criteria.len(), 2);
         assert_eq!(steering_type.criteria[0].name, "Name1");
         assert_eq!(steering_type.criteria[0].description, "Description1");
+        assert_eq!(steering_type.allowed_operations, Vec::<String>::new()); // New types default to empty
     }
 
     #[test]
@@ -318,6 +332,7 @@ mod tests {
                 name: "test criterion".to_string(),
                 description: "test description".to_string(),
             }],
+            allowed_operations: vec!["refresh".to_string()],
         };
 
         let cloned = steering_type.clone();
@@ -351,6 +366,7 @@ mod tests {
                 name: "test".to_string(),
                 purpose: "test purpose".to_string(),
                 criteria: vec![],
+                allowed_operations: vec![],
             }],
         };
 

--- a/crates/hail-mary/src/infrastructure/repositories/steering.rs
+++ b/crates/hail-mary/src/infrastructure/repositories/steering.rs
@@ -88,8 +88,8 @@ impl SteeringRepositoryInterface for SteeringRepository {
             let path = entry.path();
             let file_name = path.file_name().unwrap_or_default().to_string_lossy();
 
-            // Skip backup and draft directories
-            if file_name == "backup" || file_name == "draft" {
+            // Skip backup directory
+            if file_name == "backup" {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- Implement allowed_operations field for fine-grained control over steering file updates
- Update documentation for /hm:steering-remember and /hm:steering commands
- New steering types default to manual-only mode for safety

## Key Features
- `allowed_operations` field controls automatic updates via `/hm:steering` command
- Options: `["refresh", "discover"]` for both, `["refresh"]` for updates only, `["discover"]` for new only, `[]` for manual-only
- New steering types default to `[]` (manual-only) for safety
- Task agents investigate comprehensively, filtering happens in aggregation phase

## Changes Made
1. **Documentation Updates**
   - Updated `.claude/commands/hm/steering-remember.md` to document allowed_operations field
   - Updated `.claude/commands/hm/steering.md` to respect allowed_operations during investigation

2. **Design Decisions**
   - Task agents collect all information, main process filters based on allowed_operations
   - Default new types to empty array for conservative approach
   - Clear separation between investigation (comprehensive) and application (filtered)

## Test Plan
- All existing tests pass (134 tests)
- Documentation changes maintain consistency with implementation
- New steering types created with `/hm:steering-remember` will have empty allowed_operations array